### PR TITLE
Improve dependencies management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-sphinx
-jupyter-book
-matplotlib
-numpy
-scipy
-ghp-import
+jupyter-book>=1,<2
+matplotlib>=3,<4
+scipy>=1,<2
+ghp-import>=2,<3


### PR DESCRIPTION
Pin all dependencies to current major versions to prevent breaking changes sneaking in, but allow minor and patch upgrades.

Remove `numpy` as top level dependency as it's a core dependency of both `scipy` and `matplotlib`. Remove `sphinx` as top level dependency as it's a core dependency of `jupyter-book`.